### PR TITLE
resize descriptionContainer padding

### DIFF
--- a/components/projectPage/ProjectPage.module.scss
+++ b/components/projectPage/ProjectPage.module.scss
@@ -50,7 +50,7 @@
 
 @media only screen and (max-width: 600px) {
   .descriptionContainer {
-    padding-top: 10px;
+    padding: 10px 10px 0;
   }
 
   .infoContainer {


### PR DESCRIPTION
## The problem
The padding of the description container in the "project-page" was too big so in moble's screens it couldn't fit
<br/>
## My solution
I've changed the padding to a smaller size so it could be adjusted to mobiles