### PR TITLE
fix: gap between the social media icons

### DIFF
--- a/components/personCard/personCard.module.scss
+++ b/components/personCard/personCard.module.scss
@@ -38,6 +38,8 @@
   }
 
   &__icons {
+    display: flex;
+    gap: 4px;
     margin-top: 30px;
     align-self: flex-end;
 


### PR DESCRIPTION
## What New?
Added gap between the social media icons in the `personCard` to make better UX